### PR TITLE
Adapt to the new Timer.Reset behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ b := batcher.New(commitFn, batcher.WithMaxSize[string, string](10))
 // Run the batcher in the background. Cancel the context to interrupt the batching process.
 ctx, cancel := context.WithCancel(context.Background())
 defer cancel()
+
 go func() {
   b.Batch(ctx)
 }()

--- a/batcher.go
+++ b/batcher.go
@@ -137,10 +137,7 @@ func (b *Batcher[T, R]) Batch(ctx context.Context) {
 		if commit {
 			b.commitFn(ctx, out)
 
-			// A nil channel is never selected for reading, thus preventing a timeout
-			// while receiving the next operation.
 			c = nil
-			// We reset the slice while preserving the allocated memory.
 			out = out[:0]
 		}
 
@@ -152,12 +149,6 @@ func (b *Batcher[T, R]) Batch(ctx context.Context) {
 			if t == nil {
 				t = time.NewTimer(b.timeout)
 			} else {
-				if !t.Stop() {
-					select {
-					case <-t.C:
-					default:
-					}
-				}
 				t.Reset(b.timeout)
 			}
 			c = t.C

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go.vallahaye.net/batcher
 
-go 1.21.0
+go 1.23


### PR DESCRIPTION
As of Go 1.23, the Timer's channel is synchronous (unbuffered, capacity 0), eliminating the possibility of stale values.

Closes #10