### PR TITLE
Add throttle and timeout middlewares

### DIFF
--- a/commit/throttle.go
+++ b/commit/throttle.go
@@ -1,0 +1,33 @@
+package commit
+
+import (
+	"context"
+	"time"
+
+	"go.vallahaye.net/batcher"
+)
+
+// Throttle calls the commit function at most once per time interval. It panics
+// if the commit function is nil or the interval is negative. The commit
+// function is called immediately if the context expires while waiting.
+func Throttle[T, R any](commitFn batcher.CommitFunc[T, R], interval time.Duration) batcher.CommitFunc[T, R] {
+	if commitFn == nil {
+		panic("batcher: nil commit func")
+	}
+
+	if interval < 0 {
+		panic("batcher: negative commit throttle interval")
+	}
+
+	t := time.NewTimer(0)
+	return func(ctx context.Context, ops []*batcher.Operation[T, R]) {
+		defer t.Reset(interval)
+
+		select {
+		case <-t.C:
+		case <-ctx.Done():
+		}
+
+		commitFn(ctx, ops)
+	}
+}

--- a/commit/throttle_test.go
+++ b/commit/throttle_test.go
@@ -1,0 +1,70 @@
+package commit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.vallahaye.net/batcher"
+)
+
+func TestThrottle(t *testing.T) {
+	for _, params := range []struct {
+		name      string
+		commitFn  batcher.CommitFunc[int, int]
+		interval  time.Duration
+		mustPanic bool
+	}{
+		{
+			name:      "nil commit func",
+			commitFn:  nil,
+			mustPanic: true,
+		},
+		{
+			name:      "negative interval",
+			commitFn:  func(_ context.Context, _ []*batcher.Operation[int, int]) {},
+			interval:  -1 * time.Second,
+			mustPanic: true,
+		},
+		{
+			name:     "interval equals 1s",
+			commitFn: func(_ context.Context, _ []*batcher.Operation[int, int]) {},
+			interval: 1 * time.Second,
+		},
+	} {
+		t.Run(params.name, func(t *testing.T) {
+			const dt = 100 * time.Millisecond
+
+			defer func() {
+				v := recover()
+				switch {
+				case params.mustPanic && v == nil:
+					t.Errorf("expected panic")
+				case !params.mustPanic && v != nil:
+					t.Errorf("unexpected panic: %v", v)
+				}
+			}()
+
+			commitFn := Throttle(params.commitFn, params.interval)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			const size = 3
+			for i, interval := range [size]time.Duration{0, params.interval, 0} {
+				if i == size-1 {
+					// Cancel the context to check that the commit function is called
+					// immediately.
+					cancel()
+				}
+
+				committedAt := time.Now()
+				commitFn(ctx, nil)
+
+				if elapsed := time.Since(committedAt); elapsed-dt > interval {
+					t.Errorf("unexpected interval: got %s, want %s⩲%s", elapsed, interval, dt)
+				}
+			}
+		})
+	}
+}

--- a/commit/timeout.go
+++ b/commit/timeout.go
@@ -1,0 +1,23 @@
+package commit
+
+import (
+	"context"
+	"time"
+
+	"go.vallahaye.net/batcher"
+)
+
+// Timeout calls the commit function with a timeout set to the context. It
+// panics if the commit function is nil.
+func Timeout[T, R any](commitFn batcher.CommitFunc[T, R], timeout time.Duration) batcher.CommitFunc[T, R] {
+	if commitFn == nil {
+		panic("batcher: nil commit func")
+	}
+
+	return func(parent context.Context, ops []*batcher.Operation[T, R]) {
+		ctx, cancel := context.WithTimeout(parent, timeout)
+		defer cancel()
+
+		commitFn(ctx, ops)
+	}
+}

--- a/commit/timeout_test.go
+++ b/commit/timeout_test.go
@@ -1,0 +1,54 @@
+package commit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.vallahaye.net/batcher"
+)
+
+func TestTimeout(t *testing.T) {
+	for _, params := range []struct {
+		name      string
+		commitFn  batcher.CommitFunc[int, int]
+		timeout   time.Duration
+		mustPanic bool
+	}{
+		{
+			name:      "nil commit func",
+			commitFn:  nil,
+			mustPanic: true,
+		},
+		{
+			name: "timeout equals 1s",
+			commitFn: func(ctx context.Context, _ []*batcher.Operation[int, int]) {
+				<-ctx.Done()
+			},
+			timeout: 1 * time.Second,
+		},
+	} {
+		t.Run(params.name, func(t *testing.T) {
+			const dt = 100 * time.Millisecond
+
+			defer func() {
+				v := recover()
+				switch {
+				case params.mustPanic && v == nil:
+					t.Errorf("expected panic")
+				case !params.mustPanic && v != nil:
+					t.Errorf("unexpected panic: %v", v)
+				}
+			}()
+
+			commitFn := Timeout(params.commitFn, params.timeout)
+
+			committedAt := time.Now()
+			commitFn(context.Background(), nil)
+
+			if elapsed := time.Since(committedAt); elapsed-dt > params.timeout {
+				t.Errorf("unexpected timeout: got %s, want %s⩲%s", elapsed, params.timeout, dt)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Throttling and timeouts are basic functionalities that should be added to the commit mechanism in the form of middlewares.

Closes #13