### PR TITLE
Add error signaling to all operations in a batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ Go Batcher provides a generic and versatile implementation of a batching algorit
 
 ```go
 // Define a commit function.
-commitFn := func(ctx context.Context, out []*batcher.Operation[string, string]) {
+commitFn := func(ctx context.Context, ops batcher.Operations[string, string]) {
   // Watch the context's Done channel to know when the batching process gets interrupted.
   //
   // Do something with the batch of operations.
-  //
-  // See [Operation.SetResult] and [Operation.SetError] to signal results and errors.
+  // See [Operations.SetError] to signal an error to all operations.
+  for _, op := range ops {
+    // See [Operation.SetResult] and [Operation.SetError] to signal individual results and errors.
+  }
 }
 
 // Create a batcher committing a batch every 10 operations.

--- a/batcher.go
+++ b/batcher.go
@@ -107,9 +107,9 @@ func (b *Batcher[T, R]) Send(ctx context.Context, v T) (*Operation[T, R], error)
 // the function returns after a final call to the commit function. The latter
 // is skipped if there are no latent operations.
 func (b *Batcher[T, R]) Batch(ctx context.Context) {
-	var out []*Operation[T, R]
+	var out Operations[T, R]
 	if b.maxSize != UnlimitedSize {
-		out = make([]*Operation[T, R], 0, b.maxSize)
+		out = make(Operations[T, R], 0, b.maxSize)
 	}
 
 	var (

--- a/batcher_test.go
+++ b/batcher_test.go
@@ -23,7 +23,7 @@ func TestNewBatcher(t *testing.T) {
 		},
 		{
 			name:     "negative max size",
-			commitFn: func(_ context.Context, _ []*Operation[int, int]) {},
+			commitFn: func(_ context.Context, _ Operations[int, int]) {},
 			opts: []Option[int, int]{
 				WithMaxSize[int, int](-1),
 			},
@@ -31,7 +31,7 @@ func TestNewBatcher(t *testing.T) {
 		},
 		{
 			name:     "negative timeout",
-			commitFn: func(_ context.Context, _ []*Operation[int, int]) {},
+			commitFn: func(_ context.Context, _ Operations[int, int]) {},
 			opts: []Option[int, int]{
 				WithTimeout[int, int](-1 * time.Second),
 			},
@@ -39,7 +39,7 @@ func TestNewBatcher(t *testing.T) {
 		},
 		{
 			name:     "unlimited size with no timeout",
-			commitFn: func(_ context.Context, _ []*Operation[int, int]) {},
+			commitFn: func(_ context.Context, _ Operations[int, int]) {},
 			opts: []Option[int, int]{
 				WithMaxSize[int, int](UnlimitedSize),
 				WithTimeout[int, int](NoTimeout),
@@ -48,13 +48,13 @@ func TestNewBatcher(t *testing.T) {
 		},
 		{
 			name:      "unlimited size with no timeout (no option provided)",
-			commitFn:  func(_ context.Context, _ []*Operation[int, int]) {},
+			commitFn:  func(_ context.Context, _ Operations[int, int]) {},
 			opts:      nil,
 			mustPanic: true,
 		},
 		{
 			name:     "max size equals 10",
-			commitFn: func(_ context.Context, _ []*Operation[int, int]) {},
+			commitFn: func(_ context.Context, _ Operations[int, int]) {},
 			opts: []Option[int, int]{
 				WithMaxSize[int, int](10),
 			},
@@ -63,7 +63,7 @@ func TestNewBatcher(t *testing.T) {
 		},
 		{
 			name:     "timeout equals 1s",
-			commitFn: func(_ context.Context, _ []*Operation[int, int]) {},
+			commitFn: func(_ context.Context, _ Operations[int, int]) {},
 			opts: []Option[int, int]{
 				WithTimeout[int, int](1 * time.Second),
 			},
@@ -72,7 +72,7 @@ func TestNewBatcher(t *testing.T) {
 		},
 		{
 			name:     "max size equals 10 and timeout equals 1s",
-			commitFn: func(_ context.Context, _ []*Operation[int, int]) {},
+			commitFn: func(_ context.Context, _ Operations[int, int]) {},
 			opts: []Option[int, int]{
 				WithMaxSize[int, int](10),
 				WithTimeout[int, int](1 * time.Second),
@@ -174,25 +174,25 @@ func TestBatcherBatch(t *testing.T) {
 			countedTotalSize := 0
 
 			b := &Batcher[time.Time, time.Time]{
-				commitFn: func(_ context.Context, out []*Operation[time.Time, time.Time]) {
+				commitFn: func(_ context.Context, ops Operations[time.Time, time.Time]) {
 					const dt = 100 * time.Millisecond
 
-					if len(out) == 0 {
+					if len(ops) == 0 {
 						t.Error("unfilled batch committed")
 						return
 					}
 
-					elapsed := time.Since(out[0].Value)
-					t.Logf("committed batch: len(out) = %d, elapsed = %s", len(out), elapsed)
+					elapsed := time.Since(ops[0].Value)
+					t.Logf("committed batch: len(out) = %d, elapsed = %s", len(ops), elapsed)
 
 					switch {
-					case params.maxSize != UnlimitedSize && len(out) > params.maxSize:
-						t.Errorf("unexpected batch size: got %d, want at most %d", len(out), params.maxSize)
+					case params.maxSize != UnlimitedSize && len(ops) > params.maxSize:
+						t.Errorf("unexpected batch size: got %d, want at most %d", len(ops), params.maxSize)
 					case params.timeout != NoTimeout && elapsed-dt > params.timeout:
 						t.Errorf("unexpected timeout: got %s, want at most %s⩲%s", elapsed, params.timeout, dt)
 					}
 
-					countedTotalSize += len(out)
+					countedTotalSize += len(ops)
 				},
 				maxSize: params.maxSize,
 				timeout: params.timeout,

--- a/commit.go
+++ b/commit.go
@@ -2,4 +2,4 @@ package batcher
 
 import "context"
 
-type CommitFunc[T, R any] func(context.Context, []*Operation[T, R])
+type CommitFunc[T, R any] func(context.Context, Operations[T, R])

--- a/commit/throttle.go
+++ b/commit/throttle.go
@@ -20,7 +20,7 @@ func Throttle[T, R any](commitFn batcher.CommitFunc[T, R], interval time.Duratio
 	}
 
 	t := time.NewTimer(0)
-	return func(ctx context.Context, ops []*batcher.Operation[T, R]) {
+	return func(ctx context.Context, ops batcher.Operations[T, R]) {
 		defer t.Reset(interval)
 
 		select {

--- a/commit/throttle_test.go
+++ b/commit/throttle_test.go
@@ -22,13 +22,13 @@ func TestThrottle(t *testing.T) {
 		},
 		{
 			name:      "negative interval",
-			commitFn:  func(_ context.Context, _ []*batcher.Operation[int, int]) {},
+			commitFn:  func(_ context.Context, _ batcher.Operations[int, int]) {},
 			interval:  -1 * time.Second,
 			mustPanic: true,
 		},
 		{
 			name:     "interval equals 1s",
-			commitFn: func(_ context.Context, _ []*batcher.Operation[int, int]) {},
+			commitFn: func(_ context.Context, _ batcher.Operations[int, int]) {},
 			interval: 1 * time.Second,
 		},
 	} {

--- a/commit/timeout.go
+++ b/commit/timeout.go
@@ -14,7 +14,7 @@ func Timeout[T, R any](commitFn batcher.CommitFunc[T, R], timeout time.Duration)
 		panic("batcher: nil commit func")
 	}
 
-	return func(parent context.Context, ops []*batcher.Operation[T, R]) {
+	return func(parent context.Context, ops batcher.Operations[T, R]) {
 		ctx, cancel := context.WithTimeout(parent, timeout)
 		defer cancel()
 

--- a/commit/timeout_test.go
+++ b/commit/timeout_test.go
@@ -22,7 +22,7 @@ func TestTimeout(t *testing.T) {
 		},
 		{
 			name: "timeout equals 1s",
-			commitFn: func(ctx context.Context, _ []*batcher.Operation[int, int]) {
+			commitFn: func(ctx context.Context, _ batcher.Operations[int, int]) {
 				<-ctx.Done()
 			},
 			timeout: 1 * time.Second,

--- a/operations.go
+++ b/operations.go
@@ -1,0 +1,10 @@
+package batcher
+
+type Operations[T, R any] []*Operation[T, R]
+
+// SetError signals an error to all operations.
+func (o Operations[T, R]) SetError(err error) {
+	for _, op := range o {
+		op.SetError(err)
+	}
+}

--- a/operations_test.go
+++ b/operations_test.go
@@ -1,0 +1,30 @@
+package batcher
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestOperationsSetError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	ops := make(Operations[int, int], 2)
+	for i := 0; i < len(ops); i++ {
+		ops[i] = newOperation[int, int](i)
+	}
+
+	want := errors.New("operation error")
+	ops.SetError(want)
+
+	for _, op := range ops {
+		switch _, got := op.Wait(ctx); {
+		case got == nil:
+			t.Error("expected error")
+		case !errors.Is(got, want):
+			t.Errorf("unexpected error: got %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
Signaling an error to all operations in a batch is a redundant pattern that should be abstracted by the library.

Closes #16